### PR TITLE
SVG support

### DIFF
--- a/packages/Surplus/es/dom.d.ts
+++ b/packages/Surplus/es/dom.d.ts
@@ -1,3 +1,4 @@
 export declare function createElement(tag: string, className: string | null, parent: HTMLElement | null): HTMLElement;
+export declare function createSvgElement(tag: string, className: string | null, parent: HTMLElement | null): SVGElement;
 export declare function createComment(text: string, parent: HTMLElement): Comment;
 export declare function createTextNode(text: string, parent: HTMLElement): Text;

--- a/packages/Surplus/es/dom.js
+++ b/packages/Surplus/es/dom.js
@@ -1,7 +1,16 @@
+var svgNS = "http://www.w3.org/2000/svg";
 export function createElement(tag, className, parent) {
     var el = document.createElement(tag);
     if (className)
         el.className = className;
+    if (parent)
+        parent.appendChild(el);
+    return el;
+}
+export function createSvgElement(tag, className, parent) {
+    var el = document.createElementNS(svgNS, tag);
+    if (className)
+        el.setAttribute("class", className);
     if (parent)
         parent.appendChild(el);
     return el;

--- a/packages/Surplus/index.js
+++ b/packages/Surplus/index.js
@@ -159,10 +159,19 @@ function insert$$1(range, value) {
     }
 }
 
+var svgNS = "http://www.w3.org/2000/svg";
 function createElement(tag, className, parent) {
     var el = document.createElement(tag);
     if (className)
         el.className = className;
+    if (parent)
+        parent.appendChild(el);
+    return el;
+}
+function createSvgElement(tag, className, parent) {
+    var el = document.createElementNS(svgNS, tag);
+    if (className)
+        el.setAttribute("class", className);
     if (parent)
         parent.appendChild(el);
     return el;
@@ -433,6 +442,7 @@ exports.SingleSpreadState = SingleSpreadState;
 exports.MultiSpreadState = MultiSpreadState;
 exports.S = S;
 exports.createElement = createElement;
+exports.createSvgElement = createSvgElement;
 exports.createComment = createComment;
 exports.createTextNode = createTextNode;
 

--- a/packages/surplus-preprocessor/es/compile.js
+++ b/packages/surplus-preprocessor/es/compile.js
@@ -128,8 +128,15 @@ var compile = function (ctl, opts) {
         return expr;
     }, buildDOMExpression = function (top) {
         var ids = [], statements = [], computations = [];
+        var svgPosition = null;
         var buildHtmlElement = function (node, parent, n) {
-            var tag = node.tag, properties = node.properties, content = node.content, loc = node.loc;
+            var tag = node.tag, properties = node.properties, content = node.content, loc = node.loc, depth = parent.length == 0 ? 0 : parent == "__" ? 1 : parent.substr(2).split("_").length + 1;
+            if (tag === "svg") {
+                svgPosition = { parent: parent, depth: depth, next: n + 1 };
+            }
+            else if (svgPosition && (svgPosition.depth > depth || (svgPosition.parent === parent && svgPosition.next === n))) {
+                svgPosition = null;
+            }
             if (!node.isHTML) {
                 buildInsertedSubComponent(node, parent, n);
             }
@@ -140,7 +147,7 @@ var compile = function (ctl, opts) {
                             p instanceof JSXDynamicProperty ? buildDynamicProperty(p, id_1, i, exprs_1[i], dynamic_1, spreads_1) :
                                 buildSpread(p, id_1, exprs_1[i], dynamic_1, spreads_1);
                 }).filter(function (s) { return s !== ''; }), refStmts = refs.map(function (r) { return compileSegments(r.code) + ' = '; }).join('');
-                addStatement(id_1 + " = " + refStmts + "Surplus.createElement('" + tag + "', " + (classProp_1 && classProp_1.value) + ", " + (parent || null) + ");");
+                addStatement(id_1 + " = " + refStmts + "Surplus." + (svgPosition === null ? 'createElement' : 'createSvgElement') + "('" + tag + "', " + (classProp_1 && classProp_1.value) + ", " + (parent || null) + ");");
                 if (!dynamic_1) {
                     stmts.forEach(addStatement);
                 }
@@ -167,7 +174,7 @@ var compile = function (ctl, opts) {
                     node.isStyle ? buildStyle(node, id, expr, dynamic, spreads) :
                         buildProperty(id, node.name, expr);
         }, buildProperty = function (id, prop, expr) {
-            return isAttribute(prop)
+            return svgPosition !== null || isAttribute(prop)
                 ? id + ".setAttribute(" + codeStr(prop) + ", " + expr + ");"
                 : id + "." + prop + " = " + expr + ";";
         }, buildReference = function (ref, id) { return ''; }, buildSpread = function (node, id, expr, dynamic, spreads) {

--- a/spec/preprocessor/svg.spec.js
+++ b/spec/preprocessor/svg.spec.js
@@ -1,0 +1,69 @@
+describe("Svg objects creatation", function () {
+
+    it("Svg element is in the middle of other elements", function () {
+        var code = window.SurplusPreprocessor.preprocess(`
+            var element = 
+            <section>
+                <h1>Svg Section</h1>
+                <div>
+                    <h2>Svg test</h2>
+                    <svg>
+                        <circle cx="100" cy="100" r="50" fill="red"></circle>
+                    </svg>
+                    <span>svg circle</span>
+                </div>
+                <footer>svg</footer>
+            </section>;
+            expect(element.querySelector("circle") instanceof SVGCircleElement).toBe(true)
+        `);
+
+        eval(code);
+    });
+
+    it("Svg element is the first of the parent element", function () {
+        var code = window.SurplusPreprocessor.preprocess(`
+            var element = 
+            <section>
+                <h1>Svg Section</h1>
+                <div>
+                    <svg>
+                        <circle cx="100" cy="100" r="50" fill="red"></circle>
+                    </svg>
+                </div>
+                <footer>svg</footer>
+            </section>;
+            expect(element.querySelector("circle") instanceof SVGCircleElement).toBe(true)
+        `);
+
+        eval(code);
+    });
+
+    it("Svg element is the latter of the parent element", function () {
+        var code = window.SurplusPreprocessor.preprocess(`
+            var element = 
+            <section>
+                <h1>Svg Section</h1>
+                <div>
+                    <h2>Svg test</h2>
+                    <svg>
+                        <circle cx="100" cy="100" r="50" fill="red"></circle>
+                    </svg>
+                </div>
+                <footer>svg</footer>
+            </section>;
+            expect(element.querySelector("circle") instanceof SVGCircleElement).toBe(true)
+        `);
+
+        eval(code);
+    });
+
+    it("Svg element is the root", function () {
+        var code = window.SurplusPreprocessor.preprocess(`
+            <svg>
+                <circle cx="100" cy="100" r="50" fill="red"></circle>
+            </svg>
+        `);
+
+        eval(code);
+    });
+});

--- a/src/runtime/dom.ts
+++ b/src/runtime/dom.ts
@@ -1,6 +1,15 @@
+const svgNS = "http://www.w3.org/2000/svg";
+
 export function createElement(tag : string, className : string | null, parent : HTMLElement | null) {
     var el = document.createElement(tag);
     if (className) el.className = className;
+    if (parent) parent.appendChild(el);
+    return el;
+}
+
+export function createSvgElement(tag : string, className : string | null, parent : HTMLElement | null) {
+    var el = document.createElementNS(svgNS, tag);
+    if (className) el.setAttribute("class", className);
     if (parent) parent.appendChild(el);
     return el;
 }


### PR DESCRIPTION
This is a very simple solution but it is mostly applicable.
It is aimed not to decrease the speed of runtime mode.

SVG elements creation is followed by svgPosition variable in
compiler.ts.
Only when inside SVG elements (svgPosition has a value) that uses
createSvgElement instead of createElement and setAttribute instead of
"." Otherwise if the svgPosition is null normal process continues in the
compiler.