### PR TITLE
Making style properties as optional in TSX

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -489,7 +489,7 @@ declare global {
 			srcSet?: string;
 			start?: number;
 			step?: number | string;
-			style?: CSSStyleDeclaration;
+			style?: Partial<CSSStyleDeclaration>;
 			summary?: string;
 			tabIndex?: number;
 			target?: string;


### PR DESCRIPTION
For example: 
```html
<div style={{ width: '100%' }}>test</div>
```

Above code highligted with red line in vscode because it need
 ```html
<div style={{ width: '100%' } as CSSStyleDeclaration}>test</div>
``` 
but using `style?: Partial<CSSStyleDeclaration>;`  fixes this.