### PR TITLE
README: remove extraneous parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ```javascript
 var name = S.data("world"),
-    view = <h1>Hello {name()}!</h1>;
+    view = <h1>Hello {name}!</h1>;
 document.body.appendChild(view);
 ```
 Surplus is a compiler and runtime to allow [S.js](https://github.com/adamhaile/S) applications to create high-performance web views using JSX.  Thanks to JSX, the views are clear, declarative definitions of your UI.  Thanks to S, they update automatically and efficiently as your data changes.
@@ -94,7 +94,7 @@ If your Surplus JSX expression references any S signals, then Surplus creates an
 
 ```javascript
 var text = S.data("foo"),
-    node = <span>{text()}</span>; 
+    node = <span>{text}</span>; 
 
 // node starts out equal to <span>foo</span>
 
@@ -383,7 +383,7 @@ const Counter = init => {
     const count = S.data(init);
     return (
         <div>
-            Count is: {count()}
+            Count is: {count}
             <button onClick={() => count(count() + 1)}>
                 Increment
             </button>


### PR DESCRIPTION
If I understand things properly,
- the parentheses in the first example are optional (if they are present the value will be static; this doesn't break the example but I feel it is misleading for first-timers),
- while the parentheses under "Automatic Updates" and the section on Components are incorrect (the values would be static while the examples want to demonstrate dynamic updates).

Obviously if my understanding is incorrect I'm happy to learn!