### PR TITLE
Fix jsx examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var Todo = t => ({               // our Todo constructor
        newTitle("");             // clear new title
     },
     view =                       // declarative main view
-       <div>                     
+       <div>
           <h2>Minimalist ToDos in Surplus</h2>
           <input type="text" fn={data(newTitle)}/>
           <a onClick={addTodo}> + </a>
@@ -91,7 +91,7 @@ If your Surplus JSX expression references any S signals, then Surplus creates an
 
 ```javascript
 var text = S.data("foo"),
-    node = <span>{text()}</span>; 
+    node = <span>{text()}</span>;
 
 // node starts out equal to <span>foo</span>
 
@@ -125,7 +125,7 @@ var div       = <div></div>, // an HTMLDivElement
     // ... etc
 ```
 
-JSX expressions with *lower-cased* tags create elements.  These are HTML elements, unless their tag name or context is known to be SVG (see next entry).  
+JSX expressions with *lower-cased* tags create elements.  These are HTML elements, unless their tag name or context is known to be SVG (see next entry).
 
 There are no unclosed tags in JSX: all elements must either have a closing tag `</...>` or end in `/>`,
 
@@ -147,7 +147,7 @@ var title = <title></title>; // an HTMLTitleElement
 Children of SVG elements are also SVG elements, unless their parent is the `<foreignObject>` element, in which case they are DOM elements again.
 
 ```javascript
-var svg = 
+var svg =
     <svg>
         <text>an SVGTextElement</text>
         <foreignObject>
@@ -180,7 +180,7 @@ var props = { type: "text" },
     input3 = <input {...props} />;
 ```
 
-Since Surplus creates DOM elements, the property names generally refer to DOM element properties, although there are a few special cases: 
+Since Surplus creates DOM elements, the property names generally refer to DOM element properties, although there are a few special cases:
 
 1. If Surplus can tell that the given name belongs to an attribute not a property, it will set the attribute instead.  Currently, the heuristic used to distinguish attributes from properties is &ldquo;does it have a hyphen.&rdquo;  So `<div aria-hidden="true">` will set the `aria-hidden` attribute.
 2. Some properties have aliases.  See below.
@@ -253,15 +253,15 @@ JSX defines two kinds of children, static and dynamic.
 
 ```javascript
 // static
-var div = 
+var div =
     <div>
         <span>a static child</span>
         Static child text
     </div>;
 
-// { dynamic } 
+// { dynamic }
 var span = <span>a dynamic child</span>,
-    div = 
+    div =
         <div>
             {span}
         </div>;
@@ -280,7 +280,7 @@ Like React, Surplus removes all-whitespace nodes, and text nodes are trimmed.
 
 ### Embedded function calls, aka &ldquo;Components&rdquo;
 
-JSX expressions with *upper-cased* tag names are syntactic sugar for embedded function calls.  
+JSX expressions with *upper-cased* tag names are syntactic sugar for embedded function calls.
 
 ```jsx
 <div>
@@ -335,7 +335,7 @@ If one of the build tools listed above doesn't work for you, you may need to wor
 import { compiler } from 'surplus/compiler';
 
 // simple string -> string translation, no sourcemap
-var out = compiler.compile(in); 
+var out = compiler.compile(in);
 
 // w/ appended sourcemap
 var out = compiler.compile(in, { sourcemap: 'append' });
@@ -403,7 +403,7 @@ import * as Surplus from 'surplus'; Surplus; // <- stops TS from stripping impor
 
 ### Why isn't the Surplus compiler built on Babel?
 
-Mostly for historical reasons: Surplus was originally started about 4 years ago, before Babel had become the swiss army knife of JS extension.  Surplus therefore has its own hand-written compiler, a fairly classic tokenize-parse-transform-compile implementation.  Surplus may switch to Babel in the future.  The current compiler only parses the JSX expressions, not the JS code itself, which limits the optimizations available.  
+Mostly for historical reasons: Surplus was originally started about 4 years ago, before Babel had become the swiss army knife of JS extension.  Surplus therefore has its own hand-written compiler, a fairly classic tokenize-parse-transform-compile implementation.  Surplus may switch to Babel in the future.  The current compiler only parses the JSX expressions, not the JS code itself, which limits the optimizations available.
 
 -----
 &copy; Adam Haile, 2017.  MIT License.

--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ JSX defines two kinds of children, static and dynamic.
 // static
 var div =
     <div>
-        <span>a static child</span>
-        Static child text
+        <span>a static span child</span>
+        Some static child div text
     </div>;
+```
 
+```jsx
 // { dynamic }
-var span = <span>a dynamic child</span>,
+var span = <span>child of a dynamic div</span>,
     div =
         <div>
             {span}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you aren't using one of these tools, or if you want to write your own plugin,
 
 ## Example
 
-Here is a minimalist ToDo application, which you can run on [CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010).
+Here is a minimalist ToDo application, with [a demo on CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010):
 ```jsx
 var Todo = t => ({               // our Todo constructor
        title: S.data(t.title),   // properties are S data signals

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ var name = S.data("world"),
     view = <h1>Hello {name()}!</h1>;
 document.body.appendChild(view);
 ```
+
 Surplus is a compiler and runtime to allow [S.js](https://github.com/adamhaile/S) applications to create high-performance web views using JSX.  Thanks to JSX, the views are clear, declarative definitions of your UI.  Thanks to S, they update automatically and efficiently as your data changes.
 
 ## Installation
@@ -64,6 +65,7 @@ var Todo = t => ({               // our Todo constructor
 
 document.body.appendChild(view); // add view to document
 ```
+
 Some things to note:
 - There is no `.mount()` or `.render()` command: Surplus JSX expressions return real nodes, which can be attached to the page with standard DOM commands, `document.body.appendChild(view)`.
 - There is no `.update()` command: Surplus uses [S](https://github.com/adamhaile/S) computations to build the view, so the view responds automatically to changes in S signals.
@@ -81,6 +83,7 @@ var node = <span>foo</span>;
 // since node is a real HTMLSpanElement, we can use its properties
 node.className = "bar";
 ```
+
 For a longer discussion, see [why real DOM nodes?](#why-real-dom-nodes)
 
 Creating real DOM nodes removes the entire &ldquo;middle layer&rdquo; from Surplus: there are no components, no &ldquo;lifecycle,&rdquo; no mount or diff/patch.  DOM nodes are values like any other, &ldquo;components&rdquo; are plain old functions that return DOM nodes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Surplus
 
-```javascript
+```jsx
 var name = S.data("world"),
     view = <h1>Hello {name()}!</h1>;
 document.body.appendChild(view);
@@ -76,7 +76,7 @@ For a slighlty longer example, see the standard [TodoMVC in Surplus](https://git
 
 Surplus JSX expressions create real DOM elements, not virtual elements like React or other vdom libraries.
 
-```javascript
+```jsx
 var node = <span>foo</span>;
 // since node is a real HTMLSpanElement, we can use its properties
 node.className = "bar";
@@ -89,7 +89,7 @@ Creating real DOM nodes removes the entire &ldquo;middle layer&rdquo; from Surpl
 
 If your Surplus JSX expression references any S signals, then Surplus creates an S computation to keep that part of the DOM up to date:
 
-```javascript
+```jsx
 var text = S.data("foo"),
     node = <span>{text()}</span>;
 
@@ -119,7 +119,7 @@ Surplus apps generally rank at or near the top of most javascript benchmarks.  T
 
 ### Creating HTML Elements
 
-```javascript
+```jsx
 var div       = <div></div>, // an HTMLDivElement
     input     = <input/>;    // an HTMLInputElement
     // ... etc
@@ -131,7 +131,7 @@ There are no unclosed tags in JSX: all elements must either have a closing tag `
 
 ### Creating SVG Elements
 
-```javascript
+```jsx
 var svg       = <svg></svg>, // SVGSVGElement
     svgCircle = <circle/>,   // SVGCircleElement
     svgLine   = <line/>;     // SVGLineElement
@@ -140,13 +140,13 @@ var svg       = <svg></svg>, // SVGSVGElement
 
 If the tag name matches a known SVG element, Surplus will create an SVG element instead of an HTML one.  For the small set of tag names that belong to both -- `<a>`, `<font>`, `<title>`, `<script>` and `<style>` -- Surplus creates an HTML element.
 
-```javascript
+```jsx
 var title = <title></title>; // an HTMLTitleElement
 ```
 
 Children of SVG elements are also SVG elements, unless their parent is the `<foreignObject>` element, in which case they are DOM elements again.
 
-```javascript
+```jsx
 var svg =
     <svg>
         <text>an SVGTextElement</text>
@@ -158,7 +158,7 @@ var svg =
 
 To create the SVG version of an ambiguous tag name, put it under a known SVG tag and extract it.
 
-```javascript
+```jsx
 var svg      = <svg><title>an SVGTitleElement</title></svg>,
     svgTitle = svg.firstChild;
 ```
@@ -188,7 +188,7 @@ Since Surplus creates DOM elements, the property names generally refer to DOM el
 
 You can set a property with an unknown name, and it will be assigned to the node, but it will have no effect on the DOM:
 
-```javascript
+```jsx
 var input = <input myProperty={true} />;
 input.myProperty === true;
 ```
@@ -206,7 +206,7 @@ For static and dynamic properties, aliases are normalized at compile time, for s
 
 If the same property is set multiple times on a node, the last one takes precedence:
 
-```javascript
+```jsx
 var props = { type: "radio" },
     input = <input {...props} type="text" />;
 input.type === "text";
@@ -216,7 +216,7 @@ input.type === "text";
 
 A `ref` property specifies a variable to which the given node is assigned.  This makes it easy to get a reference to internal nodes.
 
-```javascript
+```jsx
 var input,
     div = <div>
             <input ref={input} type="text" />
@@ -230,7 +230,7 @@ The `ref` property fulfills a very similar role to the `ref` property in React, 
 
 A `fn` property specifies a function to be applied to a node.  It is useful for encapsulating a bit of reusable behavior or properties.
 
-```javascript
+```jsx
 import { data } from 'surplus-fn-data'; // two-way data binding utility
 var value = S.data("foo"),
     input = <input type="text" fn={data(value)} />;
@@ -251,7 +251,7 @@ The `fn` property may be specified multiple times for a node.  Surplus provides 
 
 JSX defines two kinds of children, static and dynamic.
 
-```javascript
+```jsx
 // static
 var div =
     <div>
@@ -375,7 +375,7 @@ Surplus does have its own tradeoffs, the largest of which is that automatic upda
 
 The same way functions usually have state, via closures:
 
-```javascript
+```jsx
 const Counter = init => {
     const count = S.data(init);
     return (


### PR DESCRIPTION
### Fixes for JSX examples

- Mark JSX examples as JSX (highlighting)
- fix child elements examples as described below

### Additional documentation fix included

- cleanup (remove) _trailing_ whitespace from README.md _(updated in a force push)_
- _UPDATED: added spacing after jsx examples_
- _UPDATED: added fix to pointer to CodePen demo_

### Child elements example fixes

I found the following sample line to be confusing:
```jsx
var span = <span>a dynamic child</span>,
    // ...
```

(the `span` var itself does not seem to be a dynamic child element)

proposed change in this PR to read as follows:
```jsx
var span = <span>child of a dynamic div</span>,
    // ...
```

_Other_ child element fixes proposed in this PR:
- clarify static span child vs static child div text in the child elements example
- split static & dynamic child examples into separate `jsx` blocks