### PR TITLE
Fix examples to use const, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var Todo = t => ({               // our Todo constructor
        newTitle("");             // clear new title
     },
     view =                       // declarative main view
-       <div>                     
+       <div>
           <h2>Minimalist ToDos in Surplus</h2>
           <input type="text" fn={data(newTitle)}/>
           <a onClick={addTodo}> + </a>
@@ -91,7 +91,7 @@ If your Surplus JSX expression references any S signals, then Surplus creates an
 
 ```javascript
 var text = S.data("foo"),
-    node = <span>{text()}</span>; 
+    node = <span>{text()}</span>;
 
 // node starts out equal to <span>foo</span>
 
@@ -125,7 +125,7 @@ var div       = <div></div>, // an HTMLDivElement
     // ... etc
 ```
 
-JSX expressions with *lower-cased* tags create elements.  These are HTML elements, unless their tag name or context is known to be SVG (see next entry).  
+JSX expressions with *lower-cased* tags create elements.  These are HTML elements, unless their tag name or context is known to be SVG (see next entry).
 
 There are no unclosed tags in JSX: all elements must either have a closing tag `</...>` or end in `/>`,
 
@@ -147,7 +147,7 @@ var title = <title></title>; // an HTMLTitleElement
 Children of SVG elements are also SVG elements, unless their parent is the `<foreignObject>` element, in which case they are DOM elements again.
 
 ```javascript
-var svg = 
+var svg =
     <svg>
         <text>an SVGTextElement</text>
         <foreignObject>
@@ -180,7 +180,7 @@ var props = { type: "text" },
     input3 = <input {...props} />;
 ```
 
-Since Surplus creates DOM elements, the property names generally refer to DOM element properties, although there are a few special cases: 
+Since Surplus creates DOM elements, the property names generally refer to DOM element properties, although there are a few special cases:
 
 1. If Surplus can tell that the given name belongs to an attribute not a property, it will set the attribute instead.  Currently, the heuristic used to distinguish attributes from properties is &ldquo;does it have a hyphen.&rdquo;  So `<div aria-hidden="true">` will set the `aria-hidden` attribute.
 2. Some properties have aliases.  See below.
@@ -253,15 +253,15 @@ JSX defines two kinds of children, static and dynamic.
 
 ```javascript
 // static
-var div = 
+var div =
     <div>
         <span>a static child</span>
         Static child text
     </div>;
 
-// { dynamic } 
+// { dynamic }
 var span = <span>a dynamic child</span>,
-    div = 
+    div =
         <div>
             {span}
         </div>;
@@ -280,7 +280,7 @@ Like React, Surplus removes all-whitespace nodes, and text nodes are trimmed.
 
 ### Embedded function calls, aka &ldquo;Components&rdquo;
 
-JSX expressions with *upper-cased* tag names are syntactic sugar for embedded function calls.  
+JSX expressions with *upper-cased* tag names are syntactic sugar for embedded function calls.
 
 ```jsx
 <div>
@@ -335,7 +335,7 @@ If one of the build tools listed above doesn't work for you, you may need to wor
 import { compiler } from 'surplus/compiler';
 
 // simple string -> string translation, no sourcemap
-var out = compiler.compile(in); 
+var out = compiler.compile(in);
 
 // w/ appended sourcemap
 var out = compiler.compile(in, { sourcemap: 'append' });
@@ -403,7 +403,7 @@ import * as Surplus from 'surplus'; Surplus; // <- stops TS from stripping impor
 
 ### Why isn't the Surplus compiler built on Babel?
 
-Mostly for historical reasons: Surplus was originally started about 4 years ago, before Babel had become the swiss army knife of JS extension.  Surplus therefore has its own hand-written compiler, a fairly classic tokenize-parse-transform-compile implementation.  Surplus may switch to Babel in the future.  The current compiler only parses the JSX expressions, not the JS code itself, which limits the optimizations available.  
+Mostly for historical reasons: Surplus was originally started about 4 years ago, before Babel had become the swiss army knife of JS extension.  Surplus therefore has its own hand-written compiler, a fairly classic tokenize-parse-transform-compile implementation.  Surplus may switch to Babel in the future.  The current compiler only parses the JSX expressions, not the JS code itself, which limits the optimizations available.
 
 -----
 &copy; Adam Haile, 2017.  MIT License.

--- a/README.md
+++ b/README.md
@@ -255,12 +255,14 @@ JSX defines two kinds of children, static and dynamic.
 // static
 var div =
     <div>
-        <span>a static child</span>
-        Static child text
+        <span>a static span child</span>
+        Some static child div text
     </div>;
+```
 
+```jsx
 // { dynamic }
-var span = <span>a dynamic child</span>,
+var span = <span>child of a dynamic div</span>,
     div =
         <div>
             {span}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you aren't using one of these tools, or if you want to write your own plugin,
 
 ## Example
 
-Here is a minimalist ToDo application, which you can run on [CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010).
+Here is a minimalist ToDo application, with [a demo on CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010):
 ```jsx
 var Todo = t => ({               // our Todo constructor
        title: S.data(t.title),   // properties are S data signals

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ var name = S.data("world"),
     view = <h1>Hello {name()}!</h1>;
 document.body.appendChild(view);
 ```
+
 Surplus is a compiler and runtime to allow [S.js](https://github.com/adamhaile/S) applications to create high-performance web views using JSX.  Thanks to JSX, the views are clear, declarative definitions of your UI.  Thanks to S, they update automatically and efficiently as your data changes.
 
 ## Installation
@@ -64,6 +65,7 @@ var Todo = t => ({               // our Todo constructor
 
 document.body.appendChild(view); // add view to document
 ```
+
 Some things to note:
 - There is no `.mount()` or `.render()` command: Surplus JSX expressions return real nodes, which can be attached to the page with standard DOM commands, `document.body.appendChild(view)`.
 - There is no `.update()` command: Surplus uses [S](https://github.com/adamhaile/S) computations to build the view, so the view responds automatically to changes in S signals.
@@ -81,6 +83,7 @@ var node = <span>foo</span>;
 // since node is a real HTMLSpanElement, we can use its properties
 node.className = "bar";
 ```
+
 For a longer discussion, see [why real DOM nodes?](#why-real-dom-nodes)
 
 Creating real DOM nodes removes the entire &ldquo;middle layer&rdquo; from Surplus: there are no components, no &ldquo;lifecycle,&rdquo; no mount or diff/patch.  DOM nodes are values like any other, &ldquo;components&rdquo; are plain old functions that return DOM nodes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Surplus
 
-```javascript
+```jsx
 var name = S.data("world"),
     view = <h1>Hello {name()}!</h1>;
 document.body.appendChild(view);
@@ -76,7 +76,7 @@ For a slighlty longer example, see the standard [TodoMVC in Surplus](https://git
 
 Surplus JSX expressions create real DOM elements, not virtual elements like React or other vdom libraries.
 
-```javascript
+```jsx
 var node = <span>foo</span>;
 // since node is a real HTMLSpanElement, we can use its properties
 node.className = "bar";
@@ -89,7 +89,7 @@ Creating real DOM nodes removes the entire &ldquo;middle layer&rdquo; from Surpl
 
 If your Surplus JSX expression references any S signals, then Surplus creates an S computation to keep that part of the DOM up to date:
 
-```javascript
+```jsx
 var text = S.data("foo"),
     node = <span>{text()}</span>;
 
@@ -119,7 +119,7 @@ Surplus apps generally rank at or near the top of most javascript benchmarks.  T
 
 ### Creating HTML Elements
 
-```javascript
+```jsx
 var div       = <div></div>, // an HTMLDivElement
     input     = <input/>;    // an HTMLInputElement
     // ... etc
@@ -131,7 +131,7 @@ There are no unclosed tags in JSX: all elements must either have a closing tag `
 
 ### Creating SVG Elements
 
-```javascript
+```jsx
 var svg       = <svg></svg>, // SVGSVGElement
     svgCircle = <circle/>,   // SVGCircleElement
     svgLine   = <line/>;     // SVGLineElement
@@ -140,13 +140,13 @@ var svg       = <svg></svg>, // SVGSVGElement
 
 If the tag name matches a known SVG element, Surplus will create an SVG element instead of an HTML one.  For the small set of tag names that belong to both -- `<a>`, `<font>`, `<title>`, `<script>` and `<style>` -- Surplus creates an HTML element.
 
-```javascript
+```jsx
 var title = <title></title>; // an HTMLTitleElement
 ```
 
 Children of SVG elements are also SVG elements, unless their parent is the `<foreignObject>` element, in which case they are DOM elements again.
 
-```javascript
+```jsx
 var svg =
     <svg>
         <text>an SVGTextElement</text>
@@ -158,7 +158,7 @@ var svg =
 
 To create the SVG version of an ambiguous tag name, put it under a known SVG tag and extract it.
 
-```javascript
+```jsx
 var svg      = <svg><title>an SVGTitleElement</title></svg>,
     svgTitle = svg.firstChild;
 ```
@@ -188,7 +188,7 @@ Since Surplus creates DOM elements, the property names generally refer to DOM el
 
 You can set a property with an unknown name, and it will be assigned to the node, but it will have no effect on the DOM:
 
-```javascript
+```jsx
 var input = <input myProperty={true} />;
 input.myProperty === true;
 ```
@@ -206,7 +206,7 @@ For static and dynamic properties, aliases are normalized at compile time, for s
 
 If the same property is set multiple times on a node, the last one takes precedence:
 
-```javascript
+```jsx
 var props = { type: "radio" },
     input = <input {...props} type="text" />;
 input.type === "text";
@@ -216,7 +216,7 @@ input.type === "text";
 
 A `ref` property specifies a variable to which the given node is assigned.  This makes it easy to get a reference to internal nodes.
 
-```javascript
+```jsx
 var input,
     div = <div>
             <input ref={input} type="text" />
@@ -230,7 +230,7 @@ The `ref` property fulfills a very similar role to the `ref` property in React, 
 
 A `fn` property specifies a function to be applied to a node.  It is useful for encapsulating a bit of reusable behavior or properties.
 
-```javascript
+```jsx
 import { data } from 'surplus-fn-data'; // two-way data binding utility
 var value = S.data("foo"),
     input = <input type="text" fn={data(value)} />;
@@ -251,7 +251,7 @@ The `fn` property may be specified multiple times for a node.  Surplus provides 
 
 JSX defines two kinds of children, static and dynamic.
 
-```javascript
+```jsx
 // static
 var div =
     <div>
@@ -375,7 +375,7 @@ Surplus does have its own tradeoffs, the largest of which is that automatic upda
 
 The same way functions usually have state, via closures:
 
-```javascript
+```jsx
 const Counter = init => {
     const count = S.data(init);
     return (

--- a/README.md
+++ b/README.md
@@ -39,31 +39,42 @@ If you aren't using one of these tools, or if you want to write your own plugin,
 
 Here is a minimalist ToDo application, with [a demo on CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010):
 ```jsx
-var Todo = t => ({               // our Todo constructor
-       title: S.data(t.title),   // properties are S data signals
-       done: S.data(t.done)
+const Todo = t => ({            // our Todo constructor
+        title: S.data(t.title), // properties are data signals
+        done: S.data(t.done)
     }),
-    todos = SArray([]),          // our todos, using SArray
-    newTitle = S.data(""),       // title for new todos
-    addTodo = () => {            // push new title onto list
-       todos.push(Todo({ title: newTitle(), done: false }));
-       newTitle("");             // clear new title
-    },
-    view =                       // declarative main view
-       <div>
-          <h2>Minimalist ToDos in Surplus</h2>
-          <input type="text" fn={data(newTitle)}/>
-          <a onClick={addTodo}> + </a>
-          {todos.map(todo =>     // insert todo views
-             <div>
+    todos = SArray([]),         // our array of todos
+    newTitle = S.data(''),      // title for new todos
+    addTodo = () => {           // push new title onto list
+        todos.push(Todo({ title: newTitle(), done: false }));
+        newTitle('');           // clear new title
+    }
+
+const view =                    // declarative main view
+    <div>
+        <h3>Minimalist ToDos in Surplus</h3>
+        <input type="text" placeholder="enter todo and click +" fn={data(newTitle)}/>
+        <a onClick={addTodo}> + </a>
+        {todos.map(todo =>      // insert todo views
+            <div>
                 <input type="checkbox" fn={data(todo.done)}/>
                 <input type="text" fn={data(todo.title)}/>
                 <a onClick={() => todos.remove(todo)}>&times;</a>
-             </div>
-          )}
-       </div>;
+            </div>
+        )}
+   </div>
 
-document.body.appendChild(view); // add view to document
+document.body.appendChild(view) // add view to document
+```
+
+To add persistence in localStorage (already part of [the demo on CodePen](https://codepen.io/adamhaile/pen/ppvdGa?editors=0010)):
+```javascript
+if (localStorage.todos) // load stored todos on start
+    todos(JSON.parse(localStorage.todos).map(Todo))
+S(() =>                 // store todos whenever they change
+    localStorage.todos = JSON.stringify(todos().map(t =>
+        ({ title: t.title(), done: t.done() }))
+    ))
 ```
 
 Some things to note:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Surplus
 
 ```jsx
-var name = S.data("world"),
-    view = <h1>Hello {name()}!</h1>;
-document.body.appendChild(view);
+const name = S.data('world')
+const view = <h1>Hello {name()}!</h1>
+document.body.appendChild(view)
 ```
 
 Surplus is a compiler and runtime to allow [S.js](https://github.com/adamhaile/S) applications to create high-performance web views using JSX.  Thanks to JSX, the views are clear, declarative definitions of your UI.  Thanks to S, they update automatically and efficiently as your data changes.
@@ -21,7 +21,7 @@ The Surplus runtime must be imported as `Surplus` into any module using Surplus 
 
 ```javascript
 import * as Surplus from 'surplus'; // ES2015 modules
-var Surplus = require('surplus');   // CommonJS modules
+const Surplus = require('surplus'); // CommonJS modules
 ```
 
 ### Compiler
@@ -90,9 +90,9 @@ For a slighlty longer example, see the standard [TodoMVC in Surplus](https://git
 Surplus JSX expressions create real DOM elements, not virtual elements like React or other vdom libraries.
 
 ```jsx
-var node = <span>foo</span>;
+const node = <span>foo</span>
 // since node is a real HTMLSpanElement, we can use its properties
-node.className = "bar";
+node.className = 'bar'
 ```
 
 For a longer discussion, see [why real DOM nodes?](#why-real-dom-nodes)
@@ -104,12 +104,12 @@ Creating real DOM nodes removes the entire &ldquo;middle layer&rdquo; from Surpl
 If your Surplus JSX expression references any S signals, then Surplus creates an S computation to keep that part of the DOM up to date:
 
 ```jsx
-var text = S.data("foo"),
-    node = <span>{text()}</span>;
+const text = S.data('foo')
+const node = <span>{text()}</span>
 
 // node starts out equal to <span>foo</span>
 
-text("bar");
+text('bar')
 
 // now it's <span>bar</span>
 ```
@@ -127,16 +127,16 @@ Surplus apps generally rank at or near the top of most javascript benchmarks.  T
 
 1. Surplus&rsquo; compiler does as much work as it can at compile time, so that the runtime code can focus on the truly dynamic operations.
 
-1. Targetting real DOM nodes removes the cost of the vdom &ldquo;middle layer.&rdquo;  For instance, Surplus can compile property assignments down to direct JIT-friendly statements like `node.type = "text"`.
+1. Targetting real DOM nodes removes the cost of the vdom &ldquo;middle layer.&rdquo;  For instance, Surplus can compile property assignments down to direct JIT-friendly statements like `node.type = 'text'`.
 
 ## Documentation
 
 ### Creating HTML Elements
 
 ```jsx
-var div       = <div></div>, // an HTMLDivElement
-    input     = <input/>;    // an HTMLInputElement
-    // ... etc
+const div   = <div></div>   // an HTMLDivElement
+const input = <input/>      // an HTMLInputElement
+// ...
 ```
 
 JSX expressions with *lower-cased* tags create elements.  These are HTML elements, unless their tag name or context is known to be SVG (see next entry).
@@ -146,35 +146,35 @@ There are no unclosed tags in JSX: all elements must either have a closing tag `
 ### Creating SVG Elements
 
 ```jsx
-var svg       = <svg></svg>, // SVGSVGElement
-    svgCircle = <circle/>,   // SVGCircleElement
-    svgLine   = <line/>;     // SVGLineElement
-    // ... etc
+const svg       = <svg></svg> // SVGSVGElement
+const svgCircle = <circle/>   // SVGCircleElement
+const svgLine   = <line/>     // SVGLineElement
+// ...
 ```
 
 If the tag name matches a known SVG element, Surplus will create an SVG element instead of an HTML one.  For the small set of tag names that belong to both -- `<a>`, `<font>`, `<title>`, `<script>` and `<style>` -- Surplus creates an HTML element.
 
 ```jsx
-var title = <title></title>; // an HTMLTitleElement
+const title = <title></title> // an HTMLTitleElement
 ```
 
 Children of SVG elements are also SVG elements, unless their parent is the `<foreignObject>` element, in which case they are DOM elements again.
 
 ```jsx
-var svg =
+const svg =
     <svg>
         <text>an SVGTextElement</text>
         <foreignObject>
             <div>an HTMLDivElement</div>
         </foreignObject>
-    </svg>;
+    </svg>
 ```
 
 To create the SVG version of an ambiguous tag name, put it under a known SVG tag and extract it.
 
 ```jsx
-var svg      = <svg><title>an SVGTitleElement</title></svg>,
-    svgTitle = svg.firstChild;
+const svg      = <svg><title>an SVGTitleElement</title></svg>
+const svgTitle = svg.firstChild
 ```
 
 ### Setting properties
@@ -183,15 +183,15 @@ JSX allows static, dynamic and spread properties:
 
 ```jsx
 // static
-var input1 = <input type="text" />;
+const input1 = <input type="text" />
 
 // dynamic
-var text = "text",
-    input2 = <input type={text} />;
+const text   = 'text'
+const input2 = <input type={text} />
 
 // spread
-var props = { type: "text" },
-    input3 = <input {...props} />;
+const props  = { type: 'text' }
+const input3 = <input {...props} />
 ```
 
 Since Surplus creates DOM elements, the property names generally refer to DOM element properties, although there are a few special cases:
@@ -203,8 +203,8 @@ Since Surplus creates DOM elements, the property names generally refer to DOM el
 You can set a property with an unknown name, and it will be assigned to the node, but it will have no effect on the DOM:
 
 ```jsx
-var input = <input myProperty={true} />;
-input.myProperty === true;
+const input = <input myProperty={true} />
+console.log(input.myProperty) // true
 ```
 
 ### Property aliases
@@ -221,21 +221,21 @@ For static and dynamic properties, aliases are normalized at compile time, for s
 If the same property is set multiple times on a node, the last one takes precedence:
 
 ```jsx
-var props = { type: "radio" },
-    input = <input {...props} type="text" />;
-input.type === "text";
+const props = { type: 'radio' }
+const input = <input {...props} type="text" />
+console.log(input.type) // "text"
 ```
 
 ### Special `ref` property
 
-A `ref` property specifies a variable to which the given node is assigned.  This makes it easy to get a reference to internal nodes.
+A `ref` property specifies a constiable to which the given node is assigned.  This makes it easy to get a reference to internal nodes.
 
 ```jsx
-var input,
-    div = <div>
-            <input ref={input} type="text" />
-          </div>;
-input.type === "text";
+const input,
+      div = <div>
+                <input ref={input} type="text" />
+            </div>
+console.log(input.type) // "text"
 ```
 
 The `ref` property fulfills a very similar role to the `ref` property in React, except that since nodes are created immediately in Surplus, it does not take a function but an assignable expression.
@@ -245,12 +245,13 @@ The `ref` property fulfills a very similar role to the `ref` property in React, 
 A `fn` property specifies a function to be applied to a node.  It is useful for encapsulating a bit of reusable behavior or properties.
 
 ```jsx
-import { data } from 'surplus-fn-data'; // two-way data binding utility
-var value = S.data("foo"),
-    input = <input type="text" fn={data(value)} />;
-input.value === "foo";
-// user enters "bar" in input
-input.value === "bar";
+import { data } from 'surplus-fn-data'  // two-way data binding utility
+
+const value = S.data('foo')
+      input = <input type="text" fn={data(value)} />;
+console.log(input.value) // "foo"
+// after user enters "bar" in input:
+console.log(input.value) // "bar"
 ```
 
 The function may take an optional second parameter, which will contain any value returned by the previous invocation, aka a &lsquo;reducing&rsquo; pattern.  In typescript, the full signature looks like:
@@ -267,20 +268,20 @@ JSX defines two kinds of children, static and dynamic.
 
 ```jsx
 // static
-var div =
+const div =
     <div>
         <span>a static span child</span>
         Some static child div text
-    </div>;
+    </div>
 ```
 
 ```jsx
 // { dynamic }
-var span = <span>child of a dynamic div</span>,
-    div =
-        <div>
-            {span}
-        </div>;
+const span = <span>child of a dynamic div</span>
+const div =
+    <div>
+        {span}
+    </div>
 ```
 
 With a dynamic child, the given expression is evaluated, and its result is inserted into the child nodes according to the following rules:
@@ -351,14 +352,14 @@ If one of the build tools listed above doesn't work for you, you may need to wor
 import { compiler } from 'surplus/compiler';
 
 // simple string -> string translation, no sourcemap
-var out = compiler.compile(in);
+const out = compiler.compile(in);
 
 // w/ appended sourcemap
-var out = compiler.compile(in, { sourcemap: 'append' });
+const out = compiler.compile(in, { sourcemap: 'append' });
 
 // w/ extracted sourcemap
 // note that output is different, to return map and src
-var { out, map } = compiler.compile(in, { sourcemap: 'extract' });
+const { out, map } = compiler.compile(in, { sourcemap: 'extract' });
 ```
 
 ## FAQs
@@ -393,7 +394,7 @@ The same way functions usually have state, via closures:
 
 ```jsx
 const Counter = init => {
-    const count = S.data(init);
+    const count = S.data(init)
     return (
         <div>
             Count is: {count()}
@@ -401,7 +402,7 @@ const Counter = init => {
                 Increment
             </button>
         </div>
-    );
+    )
 };
 ```
 


### PR DESCRIPTION
- Proposed fixes to minimalist ToDo example
- Proposed fixes to other examples
- includes changes proposed in #55 (no need to merge #55 if you merge this one)

Proposed changes to minimalist ToDo example are demonstrated in my [CodePen fork](https://codepen.io/brodybits/pen/BYPKog?editors=0011). (I did not test the changes I proposed to the other examples.)

In general:
- use `const` instead of `var` whenever possible
- style: remove trailing semicolon from JSX examples (I found these to be ugly, distracting, and possibly misleading)
- use single quotes instead of double quotes in JavaScript code (double quotes within JSX element tags)